### PR TITLE
Seed config method to extend system config with other libraries.

### DIFF
--- a/tools/config/seed.config.interfaces.ts
+++ b/tools/config/seed.config.interfaces.ts
@@ -11,3 +11,8 @@ export interface Environments {
   [key: string]: string;
 }
 
+export interface ExtendPackages {
+  name: string;
+  path?: string;
+  packageMeta?: any;
+}

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import * as slash from 'slash';
 import { argv } from 'yargs';
 
-import { Environments, InjectableDependency } from './seed.config.interfaces';
+import { Environments, ExtendPackages, InjectableDependency } from './seed.config.interfaces';
 
 /************************* DO NOT CHANGE ************************
  *
@@ -545,6 +545,17 @@ export class SeedConfig {
 
   getInjectableStyleExtension() {
     return this.ENV === ENVIRONMENTS.PRODUCTION && this.ENABLE_SCSS ? 'scss' : 'css';
+  }
+
+  addPackageBundles(pack: ExtendPackages) {
+
+    if (pack.path) {
+      this.SYSTEM_CONFIG_DEV.paths[pack.name] = pack.path;
+    }
+
+    if (pack.packageMeta) {
+      this.SYSTEM_BUILDER_CONFIG.packages[pack.name] = pack.packageMeta;
+    }
   }
 
 }


### PR DESCRIPTION
Ofter we need to extend list of libraries for system config which are in `SYSTEM_CONFIG_DEV` and/or `SYSTEM_BUILDER_CONFIG`.
Method will provide short way to add it.
Can be called from project config constructor
``` ts
this.addPackageBundles({
  name: 'angular2-modal/plugins/bootstrap',
  path: 'node_modules/angular2-modal/bundles/angular2-modal.bootstrap.umd.js',
  packageMeta: {
    main: 'index.js',
    defaultExtension: 'js'
  }
});
```