### PR TITLE
Fix `TypeError` when trying to re-throw

### DIFF
--- a/src/client/app/shared/name-list/name-list.service.ts
+++ b/src/client/app/shared/name-list/name-list.service.ts
@@ -2,6 +2,11 @@ import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 
+import 'rxjs/add/observable/throw';
+import 'rxjs/add/operator/map';
+// import 'rxjs/add/operator/do';  // for debugging
+import 'rxjs/add/operator/catch';
+
 /**
  * This class provides the NameList service with methods to read names and add names.
  */
@@ -22,6 +27,7 @@ export class NameListService {
   get(): Observable<string[]> {
     return this.http.get('/assets/data.json')
                     .map((res: Response) => res.json())
+    //              .do(data => console.log('server data:', data))  // debug
                     .catch(this.handleError);
   }
 

--- a/src/client/app/shared/name-list/name-list.service.ts
+++ b/src/client/app/shared/name-list/name-list.service.ts
@@ -3,9 +3,7 @@ import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 
 import 'rxjs/add/observable/throw';
-import 'rxjs/add/operator/map';
 // import 'rxjs/add/operator/do';  // for debugging
-import 'rxjs/add/operator/catch';
 
 /**
  * This class provides the NameList service with methods to read names and add names.


### PR DESCRIPTION
without the rxjs imports, re-throwing error in `handleError` results in a `TypeError: Observable_1.Observable.throw is not a function`

I have also added in the `do` debugging lib (commented out) as its a handy tool to point out to dev's who are not familiar with rxjs (like myself)