### PR TITLE
chore(build): provide docker support

### DIFF
--- a/.docker/dist-build.development.dockerfile
+++ b/.docker/dist-build.development.dockerfile
@@ -1,0 +1,21 @@
+FROM node:6.6
+
+# prepare a user which runs everything locally! - required in child images!
+RUN useradd --user-group --create-home --shell /bin/false app
+
+ENV HOME=/home/app
+WORKDIR $HOME
+
+ENV APP_NAME=angular-seed
+
+# before switching to user we need to set permission properly
+# copy all files, except the ignored files from .dockerignore
+COPY . $HOME/$APP_NAME/
+RUN chown -R app:app $HOME/*
+
+USER app
+WORKDIR $HOME/$APP_NAME
+
+RUN npm install
+
+CMD ["npm", "start"]

--- a/.docker/dist-build.production.dockerfile
+++ b/.docker/dist-build.production.dockerfile
@@ -1,0 +1,21 @@
+FROM node:6.6
+
+# prepare a user which runs everything locally! - required in child images!
+RUN useradd --user-group --create-home --shell /bin/false app
+
+ENV HOME=/home/app
+WORKDIR $HOME
+
+ENV APP_NAME=angular-seed
+
+# before switching to user we need to set permission properly
+# copy all files, except the ignored files from .dockerignore
+COPY . $HOME/$APP_NAME/
+RUN chown -R app:app $HOME/*
+
+USER app
+WORKDIR $HOME/$APP_NAME
+
+RUN npm install
+
+CMD ["npm", "run", "serve.prod"]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# compiled output
+dist
+tmp
+
+# dependencies
+node_modules
+bower_components
+
+# IDEs and editors
+.idea
+.vscode
+.project
+.classpath
+*.launch
+.settings/
+
+# misc
+.sass-cache
+connect.lock
+coverage/*
+libpeerconnection.log
+npm-debug.log
+testem.log
+typings
+
+# e2e
+e2e/*.js
+e2e/*.map
+
+#System Files
+.DS_Store
+Thumbs.db

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,7 +6,8 @@ IF YOU DON'T FILL OUT THE FOLLOWING INFORMATION WE MIGHT CLOSE YOUR ISSUE WITHOU
 ```
 [ ] bug report => search github for a similar issue or PR before submitting
 [ ] feature request
-[ ] support request => Please do not submit support request here, instead see use [gitter](https://gitter.im/mgechev/angular2-seed) or [stackoverflow](https://stackoverflow.com/questions/tagged/angular2)```
+[ ] support request => Please do not submit support request here, instead see use [gitter](https://gitter.im/mgechev/angular2-seed) or [stackoverflow](https://stackoverflow.com/questions/tagged/angular2)
+```
 
 **Current behavior**
 <!-- Describe how the bug manifests. -->

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,12 @@
+version: '2'
+
+services:
+
+  dist-build:
+    container_name: dist-build
+    image: dist-build
+    build:
+      context: .
+      dockerfile: ./.docker/dist-build.production.dockerfile
+    ports:
+      - '5555:5555'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2'
+
+services:
+
+  dist-build:
+    container_name: dist-build
+    image: dist-build
+    build:
+      context: .
+      dockerfile: ./.docker/dist-build.development.dockerfile
+    ports:
+      - '5555:5555'


### PR DESCRIPTION
# Provide docker deployment support for separate environments

As requested in #1422 this commit provides a basic setup for docker deployment.

## Prerequisites:
- Have `docker-engine` and `docker-compose` installed
- Have a fresh clone of the project
- Right after cloning (do not run `$ npm install`, it is not neccessary), `cd` into the folder and run one of the below listed deployments.

## How to run:

For development deployment (`$ npm start` in a docker container) run the following (it will use the `docker-compose.yml`):

```bash
$ docker-compose build
$ docker-compose up -d
```

Open browser at http://localhost:5555/


For production deployment (`$ npm run serve.prod` in a docker container) run the following (explicitly using the `docker-compose.production.yml`):

```bash
$ docker-compose -f docker-compose.production.yml build
$ docker-compose -f docker-compose.production.yml up -d
```

Open browser at http://localhost:5555/

//cc @sclausen @mgechev @ludohenin 

P.S.: It would be nice to maybe even provide a production deployment which builds the application via `$ npm run build.prod` and then serving the output in an nginx container. 
I am working on something like that over here: https://github.com/TheDonDope/crudular/pull/1
Maybe @vyakymenko has some experience on the nginx deployment part?
