### PR TITLE
Set inline target to be es5

### DIFF
--- a/tools/tasks/seed/build.js.prod.ts
+++ b/tools/tasks/seed/build.js.prod.ts
@@ -9,6 +9,7 @@ const plugins = <any>gulpLoadPlugins();
 
 const INLINE_OPTIONS = {
   base: Config.TMP_DIR,
+  target: 'es5',
   useRelativePaths: true,
   removeLineBreaks: true
 };


### PR DESCRIPTION
When running build.prod in a windows environment we were receiving the following error:
```
[...]
Starting 'build.js.prod'...
error TS1125: Hexadecimal digit expected.
```
Traced it down to being caused by https://github.com/mgechev/angular-seed/blob/master/tools/tasks/seed/build.js.prod.ts#L29

Adding the appropriate target resolved the issue. Target should be coming from tsconfig.json, but that feature should be added to https://github.com/ludohenin/gulp-inline-ng2-template