### PR TITLE
Better stack trace messages in dev mode

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -36,8 +36,8 @@
   <script>
   System.import('<%= BOOTSTRAP_MODULE %>')
     .catch(function (e) {
-      console.error(e,
-        'Report this error at https://github.com/mgechev/angular2-seed/issues');
+      console.error(e.stack || e,
+        'Not expecting this error? Report it at https://github.com/mgechev/angular2-seed/issues');
     });
   </script>
   <% } %>


### PR DESCRIPTION
It's difficult to figure out what error occurred from the console with zones sometimes. Here's the before and after with this PR.

Before:
![screen shot 2016-10-31 at 4 02 32 pm](https://cloud.githubusercontent.com/assets/4655972/19869804/29c5ea88-9f84-11e6-95c7-7f793450b087.png)

After:
![screen shot 2016-10-31 at 4 03 43 pm](https://cloud.githubusercontent.com/assets/4655972/19869807/2e6cc070-9f84-11e6-9bfc-02d0996d4c4c.png)

Code added about.component to produce this error:
![screen shot 2016-10-31 at 4 04 09 pm](https://cloud.githubusercontent.com/assets/4655972/19869811/3548fabc-9f84-11e6-80fa-2a20b452d5c4.png)
