### PR TITLE
Specify ENABLE_SCSS setting via environment variable

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -282,11 +282,11 @@ export class SeedConfig {
   VERSION_NODE = '4.0.0';
 
   /**
-   * The flag to enable handling of SCSS files
-   * The default value is false. Override with the '--scss' flag.
+   * Enable SCSS stylesheet compilation.
+   * Set ENABLE_SCSS environment variable to 'true' or '1'
    * @type {boolean}
    */
-  ENABLE_SCSS = argv['scss'] || false;
+  ENABLE_SCSS = ['true', '1'].indexOf(`${process.env.ENABLE_SCSS}`.toLowerCase()) !== -1 || false;
 
   /**
    * The list of NPM dependcies to be injected in the `index.html`.

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -286,7 +286,7 @@ export class SeedConfig {
    * Set ENABLE_SCSS environment variable to 'true' or '1'
    * @type {boolean}
    */
-  ENABLE_SCSS = ['true', '1'].indexOf(`${process.env.ENABLE_SCSS}`.toLowerCase()) !== -1 || false;
+  ENABLE_SCSS = ['true', '1'].indexOf(`${process.env.ENABLE_SCSS}`.toLowerCase()) !== -1 || argv['scss'] || false;
 
   /**
    * The list of NPM dependcies to be injected in the `index.html`.


### PR DESCRIPTION
Some npm run-scripts contain multiple gulp comman-
ds (ex. e2e.ci). Multiple gulp commands may refer-
ence the ENABLE_SCSS setting; however, '--scss' is
only appended to the final command:

    gulp ... && gulp ... && gulp ... "--scss"

This results in a build error.

To provide each command in an npm run-script the
correct ENABLE_SCSS setting, set the ENABLE_SCSS
setting using an environment variable rather than
a command-line argument.

BREAKING CHANGES
1. The '--scss' no longer has any effect
2. To enable SASS support via the command line,
   one must prefix their run-script command with
   ENABLE_SCSS=1 or ENABLE_SCSS=true.