### PR TITLE
cache node_modules with dependency to package.json

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,4 +38,4 @@ notifications:
     on_build_failure: true
     on_build_status_changed: true
 
-# cache: node_modules
+cache: node_modules -> package.json


### PR DESCRIPTION
I guess caching should be possible if it is invalidated in case package.json changes