### PR TITLE
chore: updated yarn.lock after install

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -91,6 +91,14 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/gulp-filter@^3.0.29":
+  version "3.0.29"
+  resolved "https://registry.yarnpkg.com/@types/gulp-filter/-/gulp-filter-3.0.29.tgz#b81f6b98fc8268271080ef13c9e0f51ae8dff884"
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+    "@types/vinyl" "*"
+
 "@types/gulp-load-plugins@^0.0.28":
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/@types/gulp-load-plugins/-/gulp-load-plugins-0.0.28.tgz#50c1ccb6dce2a6b9e8015c23ab2cd7a5147006ec"
@@ -140,6 +148,10 @@
 "@types/mime@*":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-0.0.29.tgz#fbcfd330573b912ef59eeee14602bface630754b"
+
+"@types/minimatch@*":
+  version "2.0.29"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-2.0.29.tgz#5002e14f75e2d71e564281df0431c8c1b4a2a36a"
 
 "@types/node@*", "@types/node@^6.0.35", "@types/node@^6.0.45":
   version "6.0.45"
@@ -211,9 +223,9 @@
   dependencies:
     "@types/node" "*"
 
-"@types/yargs@^0.0.33":
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-0.0.33.tgz#1a5313b7485055f71bab4e3e2f7325981390af51"
+"@types/yargs@^0.0.34":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-0.0.34.tgz#1560429fc550c43bc41a7b7d3dfa0afbcc914a35"
 
 "@types/zone.js@^0.0.27":
   version "0.0.27"
@@ -2278,9 +2290,9 @@ gulp-sourcemaps@1.6.0:
     through2 "^2.0.0"
     vinyl "^1.0.0"
 
-gulp-sourcemaps@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/gulp-sourcemaps/-/gulp-sourcemaps-2.1.1.tgz#ddfeabc285b7b6eb82fd13cb1cfb5b50e14797ae"
+gulp-sourcemaps@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/gulp-sourcemaps/-/gulp-sourcemaps-2.2.0.tgz#dea8a4dc9aa74630a04ae9cf1871a7a08bc1310d"
   dependencies:
     acorn "4.X"
     convert-source-map "1.X"
@@ -2606,6 +2618,10 @@ ini@^1.3.4, ini@~1.3.0:
 interpret@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
+
+intl@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
 
 invariant@^2.2.0:
   version "2.2.1"
@@ -4633,7 +4649,7 @@ rimraf@^2.2.8, rimraf@^2.3.3, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@~2.5.0, rimra
   dependencies:
     glob "^7.0.5"
 
-rollup@^0.36.0:
+rollup@^0.36.3:
   version "0.36.3"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.36.3.tgz#c89ac479828924ff8f69c1d44541cb4ea2fc11fc"
   dependencies:
@@ -5118,9 +5134,9 @@ symbol-observable@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
-systemjs-builder@0.15.32:
-  version "0.15.32"
-  resolved "https://registry.yarnpkg.com/systemjs-builder/-/systemjs-builder-0.15.32.tgz#66795f104792b0302eba40950f29ed53a791cc3e"
+systemjs-builder@0.15.33:
+  version "0.15.33"
+  resolved "https://registry.yarnpkg.com/systemjs-builder/-/systemjs-builder-0.15.33.tgz#7bd4d045769a67b52f9596141ba21cd94b49910c"
   dependencies:
     babel-core "^6.9.0"
     babel-plugin-transform-cjs-system-wrapper "^0.2.1"
@@ -5132,15 +5148,21 @@ systemjs-builder@0.15.32:
     es6-template-strings "^2.0.0"
     glob "^7.0.3"
     mkdirp "^0.5.1"
-    rollup "^0.36.0"
+    rollup "^0.36.3"
     source-map "^0.5.3"
     systemjs "^0.19.39"
     traceur "0.0.105"
     uglify-js "^2.6.1"
 
-systemjs@^0.19.39, systemjs@0.19.39:
+systemjs@^0.19.39:
   version "0.19.39"
   resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-0.19.39.tgz#e513e6f91a25a37b8b607c51c7989ee0d67b9356"
+  dependencies:
+    when "^3.7.5"
+
+systemjs@0.19.40:
+  version "0.19.40"
+  resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-0.19.40.tgz#158f64a9f4ef541a7fda6b40e527ee46b6c54cd0"
   dependencies:
     when "^3.7.5"
 


### PR DESCRIPTION
I fetched the latest version of the seed and updated my dependencies with a `yarn install`. The committed file is the result of it