### PR TITLE
chore: using ts lib in node_modules for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
settings file for vscode. Assures that vscode is using the same ts compiler as specified in `node_modules/typescript/lib`