### PR TITLE
Non-working attempt to fix #1625: `npm run build.prod` is fixed, but `build.dev` breaks

### DIFF
--- a/src/client/app/system-config.ts
+++ b/src/client/app/system-config.ts
@@ -1,3 +1,3 @@
 declare var System: SystemJSLoader.System;
 
-System.config(JSON.parse('<%= SYSTEM_CONFIG_DEV %>'));
+System.config(JSON.parse('<%= JSON.stringify(SYSTEM_CONFIG_DEV) %>'));


### PR DESCRIPTION
The issue is that build.prod and build.dev interpolates the file
`src/client/app/system-config.ts` differently

With this fix, `build.prod` correctly inserts the config string into
`system-config.ts`.

Without this fix, running `build.prod` will cause the following to be
inserted into `dist/tmp/app/system-config.js`:

```
System.config(JSON.parse('[object Object]'));
```

Problem is that in dev-mode with this fix, an escaped version of this
string is inserted.

```
 $ cat dist/dev/app/system-config.js
System.config(JSON.parse('"{\"defaultJSExtensions\":true,\"paths\":{\"app/main\":\"/app/main\",\"@angular/common\":\"node_modules/@angular/common/bundles/common.umd.js\",\"@angular/compiler\":\"node_modules/@angular/compiler/bundles/compiler.umd.js\",\"@angular/core\":\"node_modules/@angular/core/bundles/core.umd.js\",\"@angular/forms\":\"node_modules/@angular/forms/bundles/forms.umd.js\",\"@angular/http\":\"node_modules/@angular/http/bundles/http.umd.js\",\"@angular/platform-browser\":\"node_modules/@angular/platform-browser/bundles/platform-browser.umd.js\",\"@angular/platform-browser-dynamic\":\"node_modules/@angular/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js\",\"@angular/router\":\"node_modules/@angular/router/bundles/router.umd.js\",\"@angular/common/testing\":\"node_modules/@angular/common/bundles/common-testing.umd.js\",\"@angular/compiler/testing\":\"node_modules/@angular/compiler/bundles/compiler-testing.umd.js\",\"@angular/core/testing\":\"node_modules/@angular/core/bundles/core-testing.umd.js\",\"@angular/http/testing\":\"node_modules/@angular/http/bundles/http-testing.umd.js\",\"@angular/platform-browser/testing\":\"node_modules/@angular/platform-browser/bundles/platform-browser-testing.umd.js\",\"@angular/platform-browser-dynamic/testing\":\"node_modules/@angular/platform-browser-dynamic/bundles/platform-browser-dynamic-testing.umd.js\",\"@angular/router/testing\":\"node_modules/@angular/router/bundles/router-testing.umd.js\",\"app/*\":\"/app/*\",\"dist/dev/*\":\"/base/dist/dev/*\",\"*\":\"node_modules/*\"},\"packages\":{}}"'));

//# sourceMappingURL=data:application/json;charset=utf8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImFwcC9zeXN0ZW0tY29uZmlnLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVBLE1BQU0sQ0FBQyxNQUFNLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQywwQ0FBMEMsQ0FBQyxDQUFDLENBQUMiLCJmaWxlIjoiYXBwL3N5c3RlbS1jb25maWcuanMiLCJzb3VyY2VzQ29udGVudCI6WyJkZWNsYXJlIHZhciBTeXN0ZW06IFN5c3RlbUpTTG9hZGVyLlN5c3RlbTtcblxuU3lzdGVtLmNvbmZpZyhKU09OLnBhcnNlKCc8JT0gSlNPTi5zdHJpbmdpZnkoU1lTVEVNX0NPTkZJR19ERVYpICU+JykpO1xuIl19

```

Seems like double escaping is the problem.