### PR TITLE
Simplify proxy middleware configuration

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -496,6 +496,28 @@ export class SeedConfig {
     }
   };
 
+  constructor() {
+    for (let proxy of this.getProxyMiddleware()) {
+      this.PLUGIN_CONFIGS['browser-sync'].middleware.push(proxy);
+    }
+  }
+
+  /**
+   * Get proxy middleware configuration. Add in your project config like:
+   * getProxyMiddleware(): Array<any> {
+   *   const proxyMiddleware = require('http-proxy-middleware');
+   *   return [
+   *     proxyMiddleware('/ws', {
+   *       ws: false,
+   *       target: 'http://localhost:3003'
+   *     })
+   *   ];
+   * }
+   */
+  getProxyMiddleware(): Array<any> {
+    return [];
+  }
+
   /**
    * Karma reporter configuration
    */

--- a/tools/tasks/seed/e2e.ts
+++ b/tools/tasks/seed/e2e.ts
@@ -1,13 +1,17 @@
 import * as express from 'express';
 import * as history from 'express-history-api-fallback';
 import * as gulp from 'gulp';
-import { resolve } from 'path';
+import { resolve, join } from 'path';
 import { protractor } from 'gulp-protractor';
+import Config from '../../config';
 
 class Protractor {
   server(port: number, dir: string) {
     let app = express();
     let root = resolve(process.cwd(), dir);
+    for (let proxy of Config.getProxyMiddleware()) {
+      app.use(proxy);
+    }
     app.use(express.static(root));
     app.use(history('index.html', { root }));
     return new Promise((resolve, reject) => {
@@ -22,11 +26,12 @@ class Protractor {
  * Executes the build process, running all e2e specs using `protractor`.
  */
 export = (done: any) => {
+  process.env.LANG='en_US.UTF-8';
   new Protractor()
-    .server(5555, './dist/prod')
+    .server(Config.PORT, Config.PROD_DEST)
     .then((server: any) => {
       gulp
-        .src('./dist/dev/**/*.e2e-spec.js')
+        .src(join(Config.DEV_DEST, '**/*.e2e-spec.js'))
         .pipe(protractor({ configFile: 'protractor.conf.js' }))
         .on('error', (error: string) => { throw error; })
         .on('end', () => { server.close(done); });

--- a/tools/utils/seed/server.ts
+++ b/tools/utils/seed/server.ts
@@ -62,6 +62,10 @@ export function serveProd() {
   let root = resolve(process.cwd(), Config.PROD_DEST);
   let server = express();
 
+  for (let proxy of Config.getProxyMiddleware()) {
+    server.use(proxy);
+  }
+
   server.use(Config.APP_BASE, express.static(root));
 
   server.use(fallback('index.html', { root }));


### PR DESCRIPTION
This change allows to add several proxy middleware configurations by adding them in project.config.ts only.
Without this change we had to add the middlewares in project.config.ts, e2e.ts and server.ts