### PR TITLE
chore: ignore generated code from vscode search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,9 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "search.exclude": {
+    "**/coverage_js": true,
+    "**/coverage": true,
+    "**/dist": true
+  }
 }


### PR DESCRIPTION
I usually do not want to search in those folders since they are generated. Maybe there are even more?