### PR TITLE
Fix nginx template file name in docker-compose.production.yml

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -26,7 +26,7 @@ services:
     ports:
       - '5555:80'
     volumes:
-      - ./.docker/nginx.conf:/etc/nginx/conf.d/b-unit.template
+      - ./.docker/nginx.conf:/etc/nginx/conf.d/angular-seed.template
       - ./dist/prod:/var/www/dist/prod
 
 networks:


### PR DESCRIPTION
Just a small fix in docker configuration for production. The file name of template was wrong so the docker could not start properly.