### PR TITLE
Fix failing AoT build

### DIFF
--- a/tools/tasks/seed/compile.ahead.prod.ts
+++ b/tools/tasks/seed/compile.ahead.prod.ts
@@ -10,7 +10,7 @@ import Config from '../../config';
 function codegen(
   ngOptions: AngularCompilerOptions, cliOptions: NgcCliOptions, program: ts.Program,
   host: ts.CompilerHost) {
-  return CodeGenerator.create(ngOptions, cliOptions, program, host).codegen({ transitiveModules: true });
+  return CodeGenerator.create(ngOptions, cliOptions, program, host).codegen();
 }
 
 const modifyFile = (path: string, mod: any = (f: string) => f) => {


### PR DESCRIPTION
As of angular/angular [b15039d](https://github.com/angular/angular/blob/b15039d228d206c8c460eca81af51a78f2fec12e/modules/%40angular/compiler-cli/src/codegen.ts) the 'transitiveModules' option has
been removed from compiler-cli CodeGenerator's 'codegen' method.
The current seed still includes this option, which causes the production AoT build to fail. 
Removing the option -- just like has been done in the angular-cli source code -- allows the production AoT build to execute successfully.