### PR TITLE
AOT compile fix for angular 2.2.3

### DIFF
--- a/tools/tasks/seed/compile.ahead.prod.ts
+++ b/tools/tasks/seed/compile.ahead.prod.ts
@@ -10,7 +10,7 @@ import Config from '../../config';
 function codegen(
   ngOptions: AngularCompilerOptions, cliOptions: NgcCliOptions, program: ts.Program,
   host: ts.CompilerHost) {
-  return CodeGenerator.create(ngOptions, cliOptions, program, host).codegen();
+  return CodeGenerator.create(ngOptions, cliOptions, program, host).codegen({ transitiveModules: true });
 }
 
 const modifyFile = (path: string, mod: any = (f: string) => f) => {


### PR DESCRIPTION
This is a revert of 35f1ebe8c7b7488419179a9ab484b8b0f54c8347  needed for
``` npm run  build.prod.exp```

* 35f1ebe8c7b7488419179a9ab484b8b0f54c8347  was needed for angular 2.2.2
* revert needed for 2.2.3