### PR TITLE
chore: vscode tslint task fixed

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
         ],
         "severity": "warning",
         "pattern": {
-          "regexp": "^\\(\\S.*\\) (\\S.*)\\[(\\d+), (\\d+)\\]:\\s+(.*)$",
+          "regexp": "^(\\S.*)\\[(\\d+), (\\d+)\\]:\\s+(.*)$",
           "file": 1,
           "line": 2,
           "column": 3,

--- a/tools/tasks/seed/tslint.ts
+++ b/tools/tasks/seed/tslint.ts
@@ -19,7 +19,7 @@ export = () => {
     '!' + join(Config.TOOLS_DIR, '**/*.d.ts')
   ];
 
-  return gulp.src(src)
+  return gulp.src(src, {'base': '.'})
     .pipe(plugins.tslint())
     .pipe(plugins.tslint.report({
       emitError: require('is-ci')


### PR DESCRIPTION
- gulp-tslint does no longer emit the rule name in the error message and therefore I had to fix the regexp for the corresponding vscode task
- `npm run lint` did no longer show the full relative path (starting from the project directory) -- might be that was actually never the case. Fixed it by adding `base` to the option of `gulp.src`. This fix is actually necessary in order that the tslint task for vscode works as expected. Without it, the linking between error and file does not work correctly.