### PR TITLE
refactor template_locals using builder

### DIFF
--- a/tools/tasks/seed/build.index.dev.ts
+++ b/tools/tasks/seed/build.index.dev.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import * as slash from 'slash';
 
 import Config from '../../config';
-import { templateLocals } from '../../utils';
+import { TemplateLocalsBuilder } from '../../utils';
 
 const plugins = <any>gulpLoadPlugins();
 
@@ -17,7 +17,7 @@ export = () => {
     .pipe(inject('shims'))
     .pipe(inject('libs'))
     .pipe(inject())
-    .pipe(plugins.template(templateLocals()))
+    .pipe(plugins.template(new TemplateLocalsBuilder().wihtoutStringifiedEnvConfig().build()))
     .pipe(gulp.dest(Config.APP_DEST));
 };
 

--- a/tools/tasks/seed/build.index.prod.ts
+++ b/tools/tasks/seed/build.index.prod.ts
@@ -4,7 +4,7 @@ import { join, sep, normalize } from 'path';
 import * as slash from 'slash';
 
 import Config from '../../config';
-import { templateLocals } from '../../utils';
+import { TemplateLocalsBuilder } from '../../utils';
 
 const plugins = <any>gulpLoadPlugins();
 
@@ -16,7 +16,7 @@ export = () => {
   return gulp.src(join(Config.APP_SRC, 'index.html'))
     .pipe(injectJs())
     .pipe(injectCss())
-    .pipe(plugins.template(templateLocals()))
+    .pipe(plugins.template(new TemplateLocalsBuilder().wihtoutStringifiedEnvConfig().build()))
     .pipe(gulp.dest(Config.APP_DEST));
 };
 

--- a/tools/tasks/seed/build.js.dev.ts
+++ b/tools/tasks/seed/build.js.dev.ts
@@ -5,12 +5,10 @@ import * as util from 'gulp-util';
 import { join/*, sep, relative*/ } from 'path';
 
 import Config from '../../config';
-import { makeTsProject, templateLocals } from '../../utils';
+import { makeTsProject, TemplateLocalsBuilder } from '../../utils';
 import { TypeScriptTask } from '../typescript_task';
 
 const plugins = <any>gulpLoadPlugins();
-
-const jsonSystemConfig = JSON.stringify(Config.SYSTEM_CONFIG_DEV);
 
 let typedBuildCounter = Config.TYPED_COMPILE_INTERVAL; // Always start with the typed build.
 
@@ -70,11 +68,7 @@ export =
         //      sourceRoot: (file: any) =>
         //        relative(file.path, PROJECT_ROOT + '/' + APP_SRC).replace(sep, '/') + '/' + APP_SRC
         //    }))
-        .pipe(plugins.template(Object.assign(
-          templateLocals(), {
-            SYSTEM_CONFIG_DEV: jsonSystemConfig
-          }
-         )))
+        .pipe(plugins.template(new TemplateLocalsBuilder().withStringifiedSystemConfigDev().build()))
         .pipe(gulp.dest(Config.APP_DEST));
       }
   };

--- a/tools/tasks/seed/build.js.e2e.ts
+++ b/tools/tasks/seed/build.js.e2e.ts
@@ -3,10 +3,9 @@ import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join } from 'path';
 
 import Config from '../../config';
-import { makeTsProject, templateLocals } from '../../utils';
+import { makeTsProject, TemplateLocalsBuilder } from '../../utils';
 
 const plugins = <any>gulpLoadPlugins();
-const jsonSystemConfig = JSON.stringify(Config.SYSTEM_CONFIG_DEV);
 
 /**
  * Executes the build process, transpiling the TypeScript files (including the e2e-spec files, excluding the spec files)
@@ -25,8 +24,6 @@ export = () => {
 
   return result.js
     .pipe(plugins.sourcemaps.write())
-    .pipe(plugins.template(Object.assign(templateLocals(), {
-      SYSTEM_CONFIG_DEV: jsonSystemConfig
-    })))
+    .pipe(plugins.template(new TemplateLocalsBuilder().withStringifiedSystemConfigDev().build()))
     .pipe(gulp.dest(Config.E2E_DEST));
 };

--- a/tools/tasks/seed/build.js.prod.exp.ts
+++ b/tools/tasks/seed/build.js.prod.exp.ts
@@ -4,7 +4,7 @@ import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join } from 'path';
 
 import Config from '../../config';
-import { makeTsProject, templateLocals } from '../../utils';
+import { makeTsProject, TemplateLocalsBuilder } from '../../utils';
 
 const plugins = <any>gulpLoadPlugins();
 
@@ -32,7 +32,7 @@ export = () => {
     });
 
   return result.js
-    .pipe(plugins.template(templateLocals()))
+    .pipe(plugins.template(new TemplateLocalsBuilder().build()))
     .pipe(gulp.dest(Config.TMP_DIR))
     .on('error', (e: any) => {
       console.log(e);

--- a/tools/tasks/seed/build.js.prod.ts
+++ b/tools/tasks/seed/build.js.prod.ts
@@ -3,7 +3,7 @@ import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join } from 'path';
 
 import Config from '../../config';
-import { makeTsProject, templateLocals } from '../../utils';
+import { makeTsProject, TemplateLocalsBuilder } from '../../utils';
 
 const plugins = <any>gulpLoadPlugins();
 
@@ -35,7 +35,7 @@ export = () => {
 
 
   return result.js
-    .pipe(plugins.template(templateLocals()))
+    .pipe(plugins.template(new TemplateLocalsBuilder().build()))
     .pipe(gulp.dest(Config.TMP_DIR))
     .on('error', (e: any) => {
       console.log(e);

--- a/tools/tasks/seed/build.tools.ts
+++ b/tools/tasks/seed/build.tools.ts
@@ -3,16 +3,13 @@ import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join } from 'path';
 
 import Config from '../../config';
-import { makeTsProject, templateLocals } from '../../utils';
+import { makeTsProject, TemplateLocalsBuilder } from '../../utils';
 
 const plugins = <any>gulpLoadPlugins();
 
 /**
  * Executes the build process, transpiling the TypeScript files within the `tools` directory.
  */
-
-const locals = templateLocals();
-
 export = () => {
 
   let tsProject = makeTsProject();
@@ -28,7 +25,7 @@ export = () => {
     .pipe(tsProject());
 
   return result.js
-    .pipe(plugins.template(locals))
+    .pipe(plugins.template(new TemplateLocalsBuilder().build()))
     .pipe(plugins.sourcemaps.write())
     .pipe(gulp.dest('./'));
 };

--- a/tools/utils/seed/template_locals.ts
+++ b/tools/utils/seed/template_locals.ts
@@ -4,35 +4,56 @@ import { join } from 'path';
 
 import Config from '../../config';
 
-const getConfig = (path: string, env: string): any => {
-  const configPath = join(path, env);
-  let config: any;
-  try {
-    config = JSON.parse(JSON.stringify(require(configPath)));
-  } catch (e) {
-    config = null;
-    util.log(util.colors.red(e.message));
-  }
-
-  return config;
-};
-
 /**
- * Returns the project configuration (consisting of the base configuration provided by seed.config.ts and the additional
- * project specific overrides as defined in project.config.ts)
+ * Builds an object consisting of the base configuration provided by confg/seed.config.ts, the additional
+ * project specific overrides as defined in config/project.config.ts and including the base environment config as defined in env/base.ts
+ * and the environment specific overrides (for instance if env=dev then as defined in env/dev.ts).
  */
-export function templateLocals() {
-  const configEnvName = argv['env-config'] || argv['config-env'] || 'dev';
-  const configPath = Config.getPluginConfig('environment-config');
-  const baseConfig = getConfig(configPath, 'base');
-  const config = getConfig(configPath, configEnvName);
+export class TemplateLocalsBuilder {
+  private stringifySystemConfigDev = false;
+  private stringifyEnvConfig = true;
 
-  if (!config) {
-    throw new Error(configEnvName + ' is an invalid configuration name');
+  withStringifiedSystemConfigDev() {
+    this.stringifySystemConfigDev = true;
+    return this;
+  }
+  wihtoutStringifiedEnvConfig() {
+    this.stringifyEnvConfig = false;
+    return this;
   }
 
-  return Object.assign(Config, {
-    ENV_CONFIG: JSON.stringify(Object.assign(baseConfig, config))
-  });
-}
 
+  build() {
+    const configEnvName = argv['env-config'] || argv['config-env'] || 'dev';
+    const configPath = Config.getPluginConfig('environment-config');
+    const envOnlyConfig = this.getConfig(configPath, configEnvName);
+    const baseConfig = this.getConfig(configPath, 'base');
+
+    if (!envOnlyConfig) {
+      throw new Error(configEnvName + ' is an invalid configuration name');
+    }
+
+    const envConfig = Object.assign({}, baseConfig, envOnlyConfig);
+    let locals = Object.assign({},
+      Config,
+      { ENV_CONFIG: this.stringifyEnvConfig ? JSON.stringify(envConfig) : envConfig }
+    );
+    if (this.stringifySystemConfigDev) {
+      Object.assign(locals, {SYSTEM_CONFIG_DEV: JSON.stringify(Config.SYSTEM_CONFIG_DEV)});
+    }
+    return locals;
+  }
+
+  private getConfig(path: string, env: string) {
+    const configPath = join(path, env);
+    let config: any;
+    try {
+      config = JSON.parse(JSON.stringify(require(configPath)));
+    } catch (e) {
+      config = null;
+      util.log(util.colors.red(e.message));
+    }
+
+    return config;
+  };
+}


### PR DESCRIPTION
- the builder enables easier configuration without code duplication
- removed the side effects of `Object.assign` by introducing a new object `locals`
  (ENV_CONFIG was added to Config previously)
- using a un-stringified ENV_CONFIG to build index.html enables to refer to
  properties in index.html by <%= ENV_CONFIG.MY_PROPERTY %>