### PR TITLE
tslint should not lint d.ts files

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
   "tasks": [
     {
       "taskName": "tslint",
-      "args": [ "run", "gulp", "tslint", "--color" ],
+      "args": [ "run", "lint" ],
       "problemMatcher": {
         "owner": "tslint",
         "fileLocation": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "e2e.live": "protractor --elementExplorer",
     "gulp": "gulp",
     "i18n": "ng-xi18n && gulp clean.i18n",
-    "lint": "tslint src/**/*.ts tools/**/*.ts",
+    "lint": "tslint -e **/*.d.ts src/**/*.ts tools/**/*.ts",
     "karma": "karma",
     "karma.start": "karma start",
     "postinstall": "gulp check.versions && gulp build.bundle.rxjs && npm prune && gulp webdriver && gulp print.banner",

--- a/tools/tasks/seed/e2e.ts
+++ b/tools/tasks/seed/e2e.ts
@@ -26,7 +26,7 @@ class Protractor {
  * Executes the build process, running all e2e specs using `protractor`.
  */
 export = (done: any) => {
-  process.env.LANG='en_US.UTF-8';
+  process.env.LANG = 'en_US.UTF-8';
   new Protractor()
     .server(Config.PORT, Config.PROD_DEST)
     .then((server: any) => {


### PR DESCRIPTION
- thus added a `-e` option to the tslint command
- fixed the tslint task for vscode
- and fixed a tslint issue "missing whitespace"