### PR TITLE
Add gulp-tslint back in. It now supports tslint v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "gulp-sourcemaps": "2.2.0",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.0.2",
+    "gulp-tslint": "7.0.1",
     "gulp-uglify": "^2.0.0",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^4.3.10",

--- a/tools/tasks/seed/tslint.ts
+++ b/tools/tasks/seed/tslint.ts
@@ -1,28 +1,27 @@
-// import * as gulp from 'gulp';
-// import * as gulpLoadPlugins from 'gulp-load-plugins';
-// import { join } from 'path';
-// 
-// import Config from '../../config';
-// 
-// const plugins = <any>gulpLoadPlugins();
+import * as gulp from 'gulp';
+import * as gulpLoadPlugins from 'gulp-load-plugins';
+import { join } from 'path';
+
+import Config from '../../config';
+
+const plugins = <any>gulpLoadPlugins();
 
 /**
  * Executes the build process, linting the TypeScript files using `codelyzer`.
  */
-export = (done: any) => {
-  done();
-//  let src = [
-//    join(Config.APP_SRC, '**/*.ts'),
-//    '!' + join(Config.APP_SRC, '**/*.d.ts'),
-//      join(Config.E2E_SRC, '**/*.ts'),
-//    '!' + join(Config.E2E_SRC, '**/*.d.ts'),
-//    join(Config.TOOLS_DIR, '**/*.ts'),
-//    '!' + join(Config.TOOLS_DIR, '**/*.d.ts')
-//  ];
-//
-//  return gulp.src(src, {'base': '.'})
-//    .pipe(plugins.tslint())
-//    .pipe(plugins.tslint.report({
-//      emitError: require('is-ci')
-//    }));
+export = () => {
+  let src = [
+    join(Config.APP_SRC, '**/*.ts'),
+    '!' + join(Config.APP_SRC, '**/*.d.ts'),
+      join(Config.E2E_SRC, '**/*.ts'),
+    '!' + join(Config.E2E_SRC, '**/*.d.ts'),
+    join(Config.TOOLS_DIR, '**/*.ts'),
+    '!' + join(Config.TOOLS_DIR, '**/*.d.ts')
+  ];
+
+  return gulp.src(src, {'base': '.'})
+    .pipe(plugins.tslint())
+    .pipe(plugins.tslint.report({
+      emitError: require('is-ci')
+    }));
 };


### PR DESCRIPTION
I simply added the latest version of gulp-tslint back into package.json and reverted the gulp task for tslint back to its former state. npm install and test both run and pass. tslint task was able to find issues when manually introduced into the code.

PR where dependency was removed: https://github.com/mgechev/angular-seed/pull/1681 