### PR TITLE
Modify tslint / @angular/router package versions to fix NPM warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "tildify": "^1.2.0",
     "traceur": "^0.0.111",
     "ts-node": "^1.4.3",
-    "tslint": "^4.0.0",
+    "tslint": "~4.0.0",
     "typescript": "~2.0.9",
     "walk": "^2.3.9",
     "yargs": "^6.0.0"
@@ -132,7 +132,7 @@
     "@angular/http": "~2.3.1",
     "@angular/platform-browser": "~2.3.1",
     "@angular/platform-browser-dynamic": "~2.3.1",
-    "@angular/router": "~3.2.0",
+    "@angular/router": "~3.3.1",
     "core-js": "^2.4.1",
     "intl": "^1.2.5",
     "reflect-metadata": "^0.1.8",


### PR DESCRIPTION
Router should be set to version compatible with other Angular 2.3.x packages. TSLint needed to be set to 4.0.x because codelyzer requires that.