### PR TITLE
Add protractor import statements to e2e specs

### DIFF
--- a/src/e2e/specs/about.component.e2e-spec.ts
+++ b/src/e2e/specs/about.component.e2e-spec.ts
@@ -1,3 +1,5 @@
+import { browser, element, by } from 'protractor';
+
 describe('About', () => {
 
   beforeEach(async () => {

--- a/src/e2e/specs/app.component.e2e-spec.ts
+++ b/src/e2e/specs/app.component.e2e-spec.ts
@@ -1,3 +1,5 @@
+import { browser, element, by } from 'protractor';
+
 describe('App', () => {
 
   beforeEach(async () => {

--- a/src/e2e/specs/home.component.e2e-spec.ts
+++ b/src/e2e/specs/home.component.e2e-spec.ts
@@ -1,3 +1,5 @@
+import { browser, element, by } from 'protractor';
+
 describe('Home', () => {
 
   beforeEach(async () => {


### PR DESCRIPTION
TS2304 errors are occurring during the e2e.ci task:

    src/e2e/specs/about.component.e2e-spec.ts(4,18): error TS2304: Cannot find name 'browser'.
    ...

The webstorm editor also shows import error warnings, which can be
distracting.

This may be because @types/protractor was removed. The 'protractor'
module now contains the necessary typings.

Adding an import statement silenced the webstorm editor warnings as
well as the TS2304 warnings that occurred during e2e.ci execution.