### PR TITLE
feat: User defined watch paths

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -301,6 +301,12 @@ export class SeedConfig {
   ENABLE_SCSS = ['true', '1'].indexOf(`${process.env.ENABLE_SCSS}`.toLowerCase()) !== -1 || argv['scss'] || false;
 
   /**
+   * Extra paths for the gulp process to watch for to trigger compilation.
+   * @type {string[]}
+   */
+  EXTRA_WATCH_PATHS: string[] = [];
+
+  /**
    * The list of NPM dependcies to be injected in the `index.html`.
    * @type {InjectableDependency[]}
    */

--- a/tools/utils/seed/watch.ts
+++ b/tools/utils/seed/watch.ts
@@ -18,6 +18,13 @@ export function watch(taskname: string, root: string = Config.APP_SRC) {
       join(root, '**')
     ].concat(Config.TEMP_FILES.map((p) => { return '!' + p; }));
 
+    // watches for user defined paths to trigger compilation
+    if (Config.EXTRA_WATCH_PATHS) {
+      paths = paths.concat(Config.EXTRA_WATCH_PATHS.map((p) => {
+        return join(p, '**');
+      }));
+    }
+
     plugins.watch(paths, (e: any) => {
       changeFileManager.addFile(e.path);
 


### PR DESCRIPTION
Allow users to use project settings to include external directories aside from app src directory to trigger compilation.

Example config from actual project:

![image](https://cloud.githubusercontent.com/assets/4655972/21961737/1e592da8-dae0-11e6-8569-1f6205cd480d.png)

Useful for when coupled with gulp-sass includePaths settings:
![image](https://cloud.githubusercontent.com/assets/4655972/21961742/32ad4226-dae0-11e6-81e4-af51d16dc2ec.png)
