### PR TITLE
feat: zone.js long stack traces for dev

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -306,6 +306,7 @@ export class SeedConfig {
    */
   NPM_DEPENDENCIES: InjectableDependency[] = [
     { src: 'zone.js/dist/zone.js', inject: 'libs' },
+    { src: 'zone.js/dist/long-stack-trace-zone.js', inject: 'libs', buildType: BUILD_TYPES.DEVELOPMENT },
     { src: 'core-js/client/shim.min.js', inject: 'shims' },
     { src: 'intl/dist/Intl.min.js', inject: 'shims' },
     { src: 'systemjs/dist/system.src.js', inject: 'shims', buildType: BUILD_TYPES.DEVELOPMENT },


### PR DESCRIPTION
Sample code in about component:

```typescript
export class AboutComponent {
    ngOnInit() {
      setTimeout(() => {
        throw new Error('blah1');
      }, 2000);
      setTimeout(() => {
        throw new Error('blah2');
      }, 2000);
      setTimeout(() => {
        throw new Error('blah3');
      }, 2000);
    }
 }
```

Error without long stack trace:
![image](https://cloud.githubusercontent.com/assets/4655972/21961845/dfa2d8f4-dae2-11e6-924c-4a8636eaa3b5.png)

Error with long stack trace:
![image](https://cloud.githubusercontent.com/assets/4655972/21961849/ec8557f4-dae2-11e6-8743-fc986979bd72.png)

