### PR TITLE
Remove protractor from client/tsconfig.json

### DIFF
--- a/src/client/tsconfig.json
+++ b/src/client/tsconfig.json
@@ -24,7 +24,6 @@
     "types": [
       "node",
       "jasmine",
-      "protractor",
       "systemjs"
     ]
   },


### PR DESCRIPTION
When upgrading to protractor v5.1.1 the typings cause problems during AoT compilation.

```
Error: Error encountered resolving symbol values statically. Could not resolve events relative to projectdir/node_modules/blocking-proxy/built/lib/webdriver_commands.d.ts., resolving symbol WebDriverCommand in projectdir/node_modules/blocking-proxy/built/lib/webdriver_commands.d.ts
    at simplifyInContext (projectdir/node_modules/@angular/compiler/bundles/compiler.umd.js:25795:27)
    at StaticReflector.simplify (projectdir/node_modules/@angular/compiler/bundles/compiler.umd.js:25807:17)
    at StaticReflector.annotations (projectdir/node_modules/@angular/compiler/bundles/compiler.umd.js:25299:84)
    at NgModuleResolver.resolve (projectdir/node_modules/@angular/compiler/bundles/compiler.umd.js:17783:86)
    at CompileMetadataResolver.getNgModuleMetadata (projectdir/node_modules/@angular/compiler/bundles/compiler.umd.js:18284:64)
    at addNgModule (projectdir/node_modules/@angular/compiler/bundles/compiler.umd.js:25065:62)
    at projectdir/node_modules/@angular/compiler/bundles/compiler.umd.js:25076:18
    at Array.forEach (native)
    at _createNgModules (projectdir/node_modules/@angular/compiler/bundles/compiler.umd.js:25075:30)
    at analyzeNgModules (projectdir/node_modules/@angular/compiler/bundles/compiler.umd.js:24950:18)
Compilation failed
```