### PR TITLE
flexbox layout for height:100% fix

### DIFF
--- a/src/client/app/app.component.css
+++ b/src/client/app/app.component.css
@@ -1,0 +1,5 @@
+:host {
+  flex: 1 1 100%;
+  display: flex;
+  flex-flow: column;
+}

--- a/src/client/app/app.component.ts
+++ b/src/client/app/app.component.ts
@@ -9,6 +9,7 @@ import './operators';
   moduleId: module.id,
   selector: 'sd-app',
   templateUrl: 'app.component.html',
+  styleUrls: ['app.component.css'],
 })
 export class AppComponent {
   constructor() {

--- a/src/client/app/shared/navbar/navbar.component.css
+++ b/src/client/app/shared/navbar/navbar.component.css
@@ -1,7 +1,6 @@
 :host {
-  border-color: #e1e1e1;
-  border-style: solid;
-  border-width: 0 0 1px;
+  border: 0 solid #e1e1e1;
+  border-bottom-width: 1px;
   display: block;
   height: 48px;
   padding: 0 16px;

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -1,14 +1,22 @@
 /* Reset */
-html,
-body,
-div {
+html, body, div {
   border: 0;
   margin: 0;
   padding: 0;
 }
 
+html, body {
+  height: 100%;
+  width: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
 /* Box-sizing border-box */
-* {
+*, *:before, *:after {
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
I was having difficulty sizing the content of the page to fill the remaining space. You can try this by applying `height: 100%` to the `:host` css property. By adjusting the body to act as a flexbox container a component can fill it's size using `flex-basis: 100%`. Example usage on my [login-form branch](https://github.com/Karasuni/angular-seed/tree/login-form).