### PR TITLE
Move env-config.interface from tools to src

### DIFF
--- a/src/client/app/shared/config/env-config.interface.ts
+++ b/src/client/app/shared/config/env-config.interface.ts
@@ -1,0 +1,6 @@
+// Feel free to extend this interface
+// depending on your app specific config.
+export interface EnvConfig {
+  API?: string;
+  ENV?: string;
+}

--- a/src/client/app/shared/config/env.config.ts
+++ b/src/client/app/shared/config/env.config.ts
@@ -1,4 +1,4 @@
-import { EnvConfig } from '../../../../../tools/env/env-config.interface';
+import { EnvConfig } from './env-config.interface';
 
 export const Config: EnvConfig = JSON.parse('<%= ENV_CONFIG %>');
 

--- a/tools/env/env-config.interface.ts
+++ b/tools/env/env-config.interface.ts
@@ -1,6 +1,1 @@
-// Feel free to extend this interface
-// depending on your app specific config.
-export interface EnvConfig {
-  API?: string;
-  ENV?: string;
-}
+export { EnvConfig } from '../../src/client/app/shared/config/env-config.interface';


### PR DESCRIPTION
First thank you for the awesome work. :)
I'm studying Angular with this project, because this project is well maintained and documented and has clean code !

I have a question.
Only `src/client/app/shared/config/env.config.ts` depends on `tools` dir.
I think application src should not depends on tools.
Because tools includes build tools, and it might be changed (to webpack or some other tool) .

I found the following project change the dependency direction. I think it is reasonable.
https://github.com/mpetkov/ng2-finance/blob/master/tools/env/config.interface.ts

I'm not sure, but the following .gitignore lines are not necessary when this change is merged.
https://github.com/mgechev/angular-seed/blob/master/.gitignore#L55...L56

Thanks,