### PR TITLE
provide rollup includes and named exports in project config

### DIFF
--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -32,6 +32,16 @@ export class ProjectConfig extends SeedConfig {
       // {src: `${this.CSS_SRC}/path-to-lib/test-lib.css`, inject: true, vendor: false},
     ];
 
+    this.ROLLUP_INCLUDE_DIR = [
+      ...this.ROLLUP_INCLUDE_DIR,
+      //'node_modules/moment/**'
+    ];
+
+    this.ROLLUP_NAMED_EXPORTS = [
+      ...this.ROLLUP_NAMED_EXPORTS,
+      //{'node_modules/immutable/dist/immutable.js': [ 'Map' ]},
+    ];
+
     // Add packages (e.g. ng2-translate)
     // let additionalPackages: ExtendPackages[] = [{
     //   name: 'ng2-translate',

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -348,6 +348,19 @@ export class SeedConfig {
   ];
 
   /**
+   * List of directories to include in commonjs
+   * @type {string[]}
+   */
+  ROLLUP_INCLUDE_DIR: string[] = ['node_modules/**'];
+
+ /**
+  * List of named export Object key value pairs
+  * key: dependencie file
+  * value: exported Objects
+  */
+  ROLLUP_NAMED_EXPORTS: any[] = [];
+
+  /**
    * Returns the array of injectable dependencies (npm dependencies and assets).
    * @return {InjectableDependency[]} The array of npm dependencies and assets.
    */
@@ -663,6 +676,16 @@ export class SeedConfig {
 
   }
 
+/**
+ * Convert named rollup array to object
+ */
+  getRollupNamedExports() {
+    let namedExports = {};
+    this.ROLLUP_NAMED_EXPORTS.map(namedExport => {
+      namedExports = Object.assign(namedExports, namedExport);
+    });
+    return namedExports;
+  }
 }
 
 /**

--- a/tools/tasks/seed/build.bundles.app.rollup.aot.ts
+++ b/tools/tasks/seed/build.bundles.app.rollup.aot.ts
@@ -22,12 +22,9 @@ const config = {
     nodeResolve({
       jsnext: true, main: true, module: true
     }),
-    commonjs({
-      include: 'node_modules/**',
-      namedExports: {
-        // 'node_modules/immutable/dist/immutable.js': [ 'Map', 'Set', 'List', 'fromJS' ],
-        // 'node_modules/ng2-dragula/ng2-dragula.js': [ 'DragulaModule', 'DragulaService' ]
-      }
+    commonjs({ //See project.config.ts to extend
+      include: Config.ROLLUP_INCLUDE_DIR,
+      namedExports: Config.getRollupNamedExports()
     })
   ]
 };


### PR DESCRIPTION
We came across a few dependencies where we had to edit this seed task to include in rollup. We would rather follow the pattern of supplying the config via project.config w/out editing the seed task. Let us know what you think.

Thanks