### PR TITLE
docs: add link to Kendo UI for Angular fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Forks of this project demonstrate how to extend and integrate with other librari
  - https://github.com/UIUXEngineering/angular2-jspm-typescript-seed - integration with [JSPM](http://jspm.io/).
  - http://ngbot.io - a chat bot built with angular-seed.
  - [angular-seed-inspinia](https://github.com/DmitriyPotapov/angular-seed-inspinia) - integration with custom design template
+ - [telerik/kendo-angular-quickstart-seed](https://github.com/telerik/kendo-angular-quickstart-seed) - integration with Kendo UI for Angular
 
 # Directory Structure
 


### PR DESCRIPTION
Adds a link to a fork demonstrating how to integrate with Kendo UI for Angular.