### PR TITLE
fix(tools): cache SCSS files only in prod build

### DIFF
--- a/tools/tasks/seed/build.html_css.ts
+++ b/tools/tasks/seed/build.html_css.ts
@@ -85,7 +85,7 @@ function getSCSSFiles(cacheName:string, filesToCompile:string[], filesToExclude:
     filesToExclude.map((path:string) => { return '!' + path; })
   );
   return gulp.src(allFiles)
-    .pipe(plugins.cached(cacheName))
+    .pipe(isProd ? plugins.cached(cacheName) : plugins.util.noop())
     .pipe(plugins.progeny())
     .pipe(filter(filteredFiles));
 }


### PR DESCRIPTION
Just like it's done for the CSS files, SCSS files should also only
cached on production build. As things were before this patch, I would
not get a rebuild of my SCSS files (as per the progeny dependency tree)
when I updated one of them. This was problematic when working in `npm
start` or `npm run start.deving` mode, and resulted in broken UI that