### PR TITLE
Update ngx-translate link and remove @types/zone.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ An [advanced option to this seed exists here](https://github.com/NathanWalker/an
 
 - [ngrx/store](https://github.com/ngrx/store) RxJS powered state management, inspired by **Redux**
 - [ngrx/effects](https://github.com/ngrx/effects) Side effect model for @ngrx/store
-- [ng2-translate](https://github.com/ocombe/ng2-translate) for i18n
+- [ngx-translate](https://github.com/ngx-translate/core) for i18n
   - Usage is optional but on by default
   - Up to you and your team how you want to utilize it. It can be easily removed if not needed.
 - [angulartics2](https://github.com/angulartics/angulartics2) Vendor-agnostic analytics for Angular applications.

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@types/selenium-webdriver": "^3.0.3",
     "@types/systemjs": "^0.20.2",
     "@types/yargs": "^6.5.0",
-    "@types/zone.js": "^0.5.12",
     "async": "^2.1.1",
     "autoprefixer": "^7.0.1",
     "browser-sync": "^2.17.3",


### PR DESCRIPTION
- Updated the link of `ngx-translate`;
- Removed the `@types/zone.js`:

`npm WARN deprecated @types/zone.js@0.5.12: This is a stub types definition for Zone.js (https://github.com/angular/zone.js). Zone.js provides its own type definitions, so you don't need @types/zone.js installed!`

It doesn't seem to be necessary, as the **WARN** above says... you can simply install **zone.js**.
