### PR TITLE
Refactored test.watch to behave like start.deving, fixes #1894

### DIFF
--- a/tools/config/seed.tasks.json
+++ b/tools/config/seed.tasks.json
@@ -90,12 +90,6 @@
     "sw.manifest.static"
   ],
 
-  "test.watch": [
-    "build.test",
-    "watch.test",
-    "karma.watch"
-  ],
-
   "serve.dev": [
     "build.dev",
     "server.start",

--- a/tools/tasks/seed/karma.run.ts
+++ b/tools/tasks/seed/karma.run.ts
@@ -1,5 +1,5 @@
-import { startKarma } from '../../utils/seed/karma.start';
 import Config from '../../config';
+import { startKarma } from '../../utils/seed/karma.start';
 
 /**
  * Executes the build process, running all unit tests using `karma`.

--- a/tools/tasks/seed/karma.run.without_coverage.ts
+++ b/tools/tasks/seed/karma.run.without_coverage.ts
@@ -1,0 +1,18 @@
+import * as karma from 'karma';
+import { join } from 'path';
+
+import Config from '../../config';
+
+let repeatableStartKarma = (done: any, config: any = {}) => {
+  return new (<any>karma).Server(Object.assign({
+    configFile: join(process.cwd(), 'karma.conf.js'),
+    singleRun: true
+  }, config), (exitCode: any) => {
+    // Karma run is finished but do not exit the process for failure. Rather just mark this task as done.
+    done();
+  }).start();
+};
+
+export = (done: any) => {
+  return repeatableStartKarma(done);
+};

--- a/tools/tasks/seed/test.watch.ts
+++ b/tools/tasks/seed/test.watch.ts
@@ -5,20 +5,17 @@ import * as runSequence from 'run-sequence';
 import Config from '../../config';
 import { notifyLiveReload, watchAppFiles } from '../../utils';
 
-gulp.task('watch.while_deving', function () {
+gulp.task('watch.while_testing', function () {
   watchAppFiles('**/!(*.ts)', (e: any, done: any) =>
-    runSequence('build.assets.dev', 'build.html_css', 'build.index.dev', () => { notifyLiveReload(e); done(); }));
+    runSequence('build.assets.dev', 'build.html_css', 'build.index.dev', done));
   watchAppFiles('**/(*.ts)', (e: any, done: any) =>
     runSequence('build.js.dev', 'build.index.dev', () => {
-      notifyLiveReload(e);
-      runSequence('build.js.test', 'karma.run.with_coverage', done);
+      runSequence('build.js.test', 'karma.run.without_coverage', done);
     }));
 });
 
 export = (done: any) =>
   runSequence('build.test',
-    'watch.while_deving',
-    'server.start',
-    'karma.run.with_coverage',
-    'serve.coverage.watch',
+    'watch.while_testing',
+    'karma.run.without_coverage',
     done);


### PR DESCRIPTION
Fix for #1894 
- moved watchAppFiles from start.deving to server to make it usable project-wide
- added test.watch as custom command which behaves similar to start.deving
- added karma.run.without_coverage, but not sure if we also just can run the karma.run.with_coverage in order to keep the codebase a bit leaner (not sure what the performance impact is)

Suggestions are welcome :-)