### PR TITLE
fix(aot):  "Unexpected moduleResolution" in typescript

### DIFF
--- a/tools/tasks/seed/build.js.prod.rollup.aot.ts
+++ b/tools/tasks/seed/build.js.prod.rollup.aot.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 
 import Config from '../../config';
 import { makeTsProject, TemplateLocalsBuilder } from '../../utils';
+import { ModuleResolutionKind } from 'typescript/lib/typescript';
 
 const plugins = <any>gulpLoadPlugins();
 
@@ -16,7 +17,7 @@ export = () => {
   const tsProject = makeTsProject({
     target: 'es2015',
     module: 'es2015',
-    moduleResolution: 'node'
+    moduleResolution: ModuleResolutionKind.NodeJs
   }, Config.TMP_DIR);
 
   let toIgnore = readdirSync(Config.TMP_DIR).filter((f: string) =>


### PR DESCRIPTION
When building prod with rollup following error appears:

`ts.Debug.fail("Unexpected moduleResolution: " + moduleResolution);`

When changing the moduleResolution to the enum, the error disappears.

See Typescript Changelog:

TypeScript 2.4

The following types/namespaces are now string enums: ts.Extension, ts.ScriptElementKind, ts.HighlightSpanKind, ts.ClassificationTypeNames, protocol.CommandTypes, protocol.IndentStyle, protocol.JsxEmit, protocol.ModuleKind, `protocol.ModuleResolutionKind`, protocol.NewLineKind, and protocol.ScriptTarget. Also, ts.CommandNames is now an alias for protocol.CommandTypes. See #15966 and #16425.