### PR TITLE
fix: css asset ordering

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -578,8 +578,8 @@ export class SeedConfig {
    */
   private get _APP_ASSETS(): InjectableDependency[] {
     return [
+	  ...this.APP_ASSETS,
       { src: `${this.CSS_SRC}/${this.CSS_BUNDLE_NAME}.${this.getInjectableStyleExtension()}`, inject: true, vendor: false },
-      ...this.APP_ASSETS,
     ];
   }
 


### PR DESCRIPTION
include APP_ASSETS before building css of seed.

This will allow people using libraries like Bootstrap to not have their custom styles overridden. With the previous ordering any changes made in you main.css/main.scss files would be overridden.