### PR TITLE
fix readme file by replacing *.routes.ts with *-routing.module.ts and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,8 +339,7 @@ Forks of this project demonstrate how to extend and integrate with other librari
 │       │   │   ├── about.component.spec.ts
 │       │   │   ├── about.component.ts
 │       │   │   ├── about.module.ts
-│       │   │   ├── about.routes.ts
-│       │   │   └── index.ts
+│       │   │   └── about-routing.module.ts
 │       │   ├── app.component.e2e-spec.ts
 │       │   ├── app.component.html
 │       │   ├── app.component.spec.ts
@@ -354,8 +353,7 @@ Forks of this project demonstrate how to extend and integrate with other librari
 │       │   │   ├── home.component.spec.ts
 │       │   │   ├── home.component.ts
 │       │   │   ├── home.module.ts
-│       │   │   ├── home.routes.ts
-│       │   │   └── index.ts
+│       │   │   └── home-routing.module.ts
 │       │   ├── i18n.providers.ts
 │       │   ├── main-prod.ts
 │       │   ├── main.ts
@@ -365,17 +363,14 @@ Forks of this project demonstrate how to extend and integrate with other librari
 │       │   │   │   └── env.config.ts
 │       │   │   ├── index.ts
 │       │   │   ├── name-list
-│       │   │   │   ├── index.ts
 │       │   │   │   ├── name-list.service.spec.ts
 │       │   │   │   └── name-list.service.ts
 │       │   │   ├── navbar
-│       │   │   │   ├── index.ts
 │       │   │   │   ├── navbar.component.css
 │       │   │   │   ├── navbar.component.html
 │       │   │   │   └── navbar.component.ts
 │       │   │   ├── shared.module.ts
 │       │   │   └── toolbar
-│       │   │       ├── index.ts
 │       │   │       ├── toolbar.component.css
 │       │   │       ├── toolbar.component.html
 │       │   │       └── toolbar.component.ts


### PR DESCRIPTION
Dear all,
this PR related to https://github.com/mgechev/angular-seed/issues/2050
fixed readme file by replacing *.routes.ts with *-routing.module.ts and remove unexists index.ts

