### PR TITLE
Added dependencies for Angular's  http client

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -484,6 +484,7 @@ export class SeedConfig {
       '@angular/platform-browser/animations':
         'node_modules/@angular/platform-browser/bundles/platform-browser-animations.umd.js',
       '@angular/common': 'node_modules/@angular/common/bundles/common.umd.js',
+      '@angular/common/http': 'node_modules/@angular/common/bundles/common-http.umd.js',
       '@angular/compiler':
         'node_modules/@angular/compiler/bundles/compiler.umd.js',
       '@angular/core': 'node_modules/@angular/core/bundles/core.umd.js',
@@ -555,6 +556,8 @@ export class SeedConfig {
         'node_modules/@angular/platform-browser/bundles/platform-browser-animations.umd.js',
       '@angular/animations/browser':
         'node_modules/@angular/animations/bundles/animations-browser.umd.js',
+      '@angular/common/http':
+        'node_modules/@angular/common/bundles/common-http.umd.js',
       'dist/tmp/node_modules/*': 'dist/tmp/node_modules/*',
       'node_modules/*': 'node_modules/*',
       '*': 'node_modules/*'


### PR DESCRIPTION
Angular's http client from @ angular/common/http should be a dependency in the seed config, not in the project config as pointed out in #2057.