### PR TITLE
chore: fix gulp-util types version (#2114)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@types/gulp-load-plugins": "^0.0.30",
     "@types/gulp-protractor": "^1.0.30",
     "@types/gulp-sass": "^0.0.30",
-    "@types/gulp-util": "^3.0.29",
+    "@types/gulp-util": "3.0.31",
     "@types/jasmine": "^2.6.0",
     "@types/node": "^8.0.34",
     "@types/rimraf": "2.0.2",


### PR DESCRIPTION
Resolves #2114

[This change](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/302970129c1698a5072e1fc94bf6cd813b554185) seems to have broken typings the way it's currently used in tasks (it's expecting `util.colors.default.foo`)