### PR TITLE
chore: Update gulp-util types

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@types/gulp-load-plugins": "^0.0.30",
     "@types/gulp-protractor": "^1.0.30",
     "@types/gulp-sass": "^0.0.30",
-    "@types/gulp-util": "3.0.31",
+    "@types/gulp-util": "^3.0.33",
     "@types/jasmine": "^2.6.0",
     "@types/node": "^8.0.34",
     "@types/rimraf": "2.0.2",


### PR DESCRIPTION
The original cause of issue #2114 appears to have been fixed so #2115 can effectively be reverted and semver latest can start being used again.

https://github.com/DefinitelyTyped/DefinitelyTyped/commit/0fca415085b80f3de023a02733ed7c39b9e3fbe0
