### PR TITLE
Fix production build when importing RxJS operators

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -560,7 +560,7 @@ export class SeedConfig {
       '@angular/common/http':
         'node_modules/@angular/common/bundles/common-http.umd.js',
       'tslib': 'node_modules/tslib/tslib.js',
-      'rxjs/operators': 'node_modules/rxjs/operators/index.js',
+      'rxjs/operators': 'node_modules/rxjs/operators.js',
       'dist/tmp/node_modules/*': 'dist/tmp/node_modules/*',
       'node_modules/*': 'node_modules/*',
       '*': 'node_modules/*'


### PR DESCRIPTION
Production is broken when importing RxJS operators be referencing 'rxjs/operators?.
seed.config.ts is pointing to a file that does not exist in RxJS 5.5.x.