### PR TITLE
Update link for Angular StyleGuide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/mgechev/angular-seed.svg)](https://greenkeeper.io/)
 
-[![Angular Style Guide](https://mgechev.github.io/angular2-style-guide/images/badge.svg)](https://angular.io/styleguide)
+[![Angular Style Guide](https://mgechev.github.io/angular2-style-guide/images/badge.svg)](https://angular.io/guide/styleguide)
 [![Build Status](https://travis-ci.org/mgechev/angular-seed.svg?branch=master)](https://travis-ci.org/mgechev/angular-seed)
 [![Build Status](https://ci.appveyor.com/api/projects/status/jg5vg36w0klpa00e/branch/master?svg=true)](https://ci.appveyor.com/project/mgechev/angular2-seed)
 [![Join the chat at https://gitter.im/mgechev/angular2-seed](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mgechev/angular2-seed?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
@@ -26,7 +26,7 @@ Provides fast, reliable and extensible starter for the development of Angular pr
 - Sample unit tests with Jasmine and Karma including code coverage via [istanbul](https://gotwarlost.github.io/istanbul/).
 - End-to-end tests with Cypress.
 - Development server with Livereload.
-- Following the [best practices](https://angular.io/styleguide).
+- Following the [best practices](https://angular.io/guide/styleguide).
 - Provides full Docker support for both development and production environment
 - Support for Angular Mobile Toolkit
 - Allows you to analyze the space usage of created bundles by using source-map-explorer


### PR DESCRIPTION
It looks like the Angular.io site has moved things and the Style Guide is now located at (https://angular.io/guide/styleguide). I have updated the main README.md to ensure it contains the correct link.