### PR TITLE
Improve production docker build - make better use of layer cache

### DIFF
--- a/.docker/Dockerfile_prod
+++ b/.docker/Dockerfile_prod
@@ -2,8 +2,11 @@ FROM node:9.11 as builder
 
 WORKDIR /home/node/angular-seed
 
-# copy all files not listed in .dockerignore
-COPY . .
+# try to make good use of docker cache: don't copy our source files until after install
+# because there is no need to bust the "npm install" cache layer if only the app source files have changed
+COPY package.json package-lock.json gulpfile.ts tsconfig.json tslint.json ./
+COPY tools ./tools/
+COPY .docker/rm.optional.deps.js ./.docker/rm.optional.deps.js
 
 # before switching to non-root user, change ownership of home
 RUN chown -R node:node .
@@ -11,9 +14,18 @@ USER node
 
 # NB: this is a workaround due to the fact that npm '--no-optional' flag doesn't work (open script below for more)
 RUN node .docker/rm.optional.deps.js
-RUN rm -r cypress && rm cypress.json
 
 RUN npm install --no-optional
+
+COPY src ./src/
+COPY .docker/rm.optional.types.js ./.docker/rm.optional.types.js
+
+# temporarily switch back to root user to fix ownership of the newly added files
+USER root
+RUN chown -R node:node src .docker/rm.optional.types.js
+USER node
+
+RUN node .docker/rm.optional.types.js
 RUN npm run build.prod.rollup.aot
 
 FROM nginx:1.13

--- a/.docker/rm.optional.deps.js
+++ b/.docker/rm.optional.deps.js
@@ -10,13 +10,3 @@ const fs = require('fs');
 const npmPackage = JSON.parse(fs.readFileSync('package.json'));
 delete npmPackage['optionalDependencies'];
 fs.writeFileSync('package.json', JSON.stringify(npmPackage, null, 2));
-
-/**
- * Todo is there a better way to handdle optional types in tsconfig.json ?
- */
-let tsConfigJson = 'src/client/tsconfig.json';  // only copied in the prod image
-if (fs.existsSync(tsConfigJson)) {
-  const tsConfig = JSON.parse(fs.readFileSync(tsConfigJson));
-  tsConfig['compilerOptions']['types'] = tsConfig['compilerOptions']['types'].filter(t => t !== 'jasmine');
-  fs.writeFileSync(tsConfigJson, JSON.stringify(tsConfig, null, 2));
-}

--- a/.docker/rm.optional.types.js
+++ b/.docker/rm.optional.types.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+
+/**
+ * Fixme is there a better way to handdle optional types in tsconfig.json ?
+ */
+let tsConfigJson = 'src/client/tsconfig.json';  // only copied in the prod image
+if (fs.existsSync(tsConfigJson)) {
+  const tsConfig = JSON.parse(fs.readFileSync(tsConfigJson));
+  tsConfig['compilerOptions']['types'] = tsConfig['compilerOptions']['types'].filter(t => t !== 'jasmine');
+  fs.writeFileSync(tsConfigJson, JSON.stringify(tsConfig, null, 2));
+}


### PR DESCRIPTION
There is no need to bust the "npm install" cache layer if only the app
source files have changed. This only applies to the prod image.